### PR TITLE
Account confirmation messages displayed on login view

### DIFF
--- a/screendoor/templates/registration/login.html
+++ b/screendoor/templates/registration/login.html
@@ -11,9 +11,23 @@
       <!-- Displays "Login" -->
       <label class="card-title col s12" for="login">{{ login_form.login_text }}</label>
       {% csrf_token %}
-      <!-- Error-display relating to e-mail address -->
       <div class="col s12">
+        <!-- Account confirmed success message -->
+        {% if account_confirmed is not None %}
+        <span class="success-text">{{ account_confirmed }}</span>
+        {% endif %}
+        <!-- Account validation error message -->
+        {% if validation_error is not None %}
+        <span class="error-text">{{ validation_error }}</span>
+        {% endif %}
+        <!-- Error-display relating to e-mail address -->
+        {% if login_form.errors.email is not None %}
         <span class="error-text">{{ login_form.errors.email }}</span>
+        {% endif %}
+        <!-- Error-display relating to password -->
+        {% if login_form.errors.password is not None %}
+        <span class="error-text">{{ login_form.errors.password }}</span>
+        {% endif %}
       </div>
       <!-- Input and label for e-mail/username -->
       <div class="input-field col s12">
@@ -24,12 +38,6 @@
       <div class="input-field col s12">
         {{ login_form.password.label_tag }}
         {{ login_form.password }}
-      </div>
-      <!-- Error-display relating to password -->
-      <div class="col s12">
-        {% if login_form.errors.password is not None %}
-        <span class="error-text">{{ login_form.errors.password }}</span>
-        {% endif %}
       </div>
       <!-- Create account and login buttons -->
       <div class="row">

--- a/screendoor/templates/registration/register.html
+++ b/screendoor/templates/registration/register.html
@@ -10,10 +10,18 @@
       <label class="card-title col s12" for="register">{{ register_form.text }}</label>
       {% csrf_token %}
       <div class="col s12">
-        <!-- Registration success message -->
-        {% if success %}<div class="success-text">{{ success }}</div>{% endif %}
+        <!-- Account created success message -->
+        {% if account_created is not None %}
+        <span class="success-text">{{ account_created }}</span>
+        {% endif %}
         <!-- Registration error messages related to e-mail address -->
+        {% if login_form.errors.email is not None %}
         <span class="error-text">{{ register_form.errors.email }}</span>
+        {% endif %}
+        <!-- Registration error messages related to password -->
+        {% if login_form.errors.password2 is not None %}
+        <span class="error-text">{{ register_form.errors.password2 }}</span>
+        {% endif %}
       </div>
       <!-- Email label and input -->
       <div class="input-field col s12">
@@ -30,13 +38,13 @@
         {{ register_form.password2.label_tag }}
         {{ register_form.password2 }}
       </div>
-      <!-- Registration error messages related to password -->
-      <div class="col s12">
-        <span class="error-text">{{ register_form.errors.password2 }}</span>
-      </div>
       <!-- Create account button and login redirect button -->
       <div class="row">
+        {% if account_created is not None %}
+        <input class="right btn btn-margin disabled" type="submit" value="{{ register_form.text }}">
+        {% else %}
         <input class="right btn btn-margin" type="submit" value="{{ register_form.text }}">
+        {% endif %}
         <a class="btn-flat btn-margin waves-effect right" href="{% url 'login' %}">{{ register_form.login_button_text }}</a>
       </div>
     </div>

--- a/screendoor/urls.py
+++ b/screendoor/urls.py
@@ -11,6 +11,6 @@ urlpatterns = [
     path('register/', views.register_form, name='register'),
     path('login/', views.login_form, name='login'),
     path('logout/', views.logout_view, name='logout'),
-    path('confirm/', views.confirm_account, name='confirm_account'),
+    path('confirm/', views.login_form, name='confirm_account'),
     path('createnewposition/', views.import_position, name='importposition'),
 ]

--- a/screendoor/uservisibletext.py
+++ b/screendoor/uservisibletext.py
@@ -10,13 +10,16 @@ class StandardFormText():
 
 class ErrorMessages():
     # Translators: When a user tries to upload a blank position form.
-    empty_create_position_form = _('Please enter either a pdf file or a url link.')
+    empty_create_position_form = _(
+        'Please enter either a pdf file or a url link.')
     # Translators: When a user tries to upload a position form with too much data.
-    overfilled_create_position_form = _('Please enter *either* a pdf file or a url link, but not both.')
+    overfilled_create_position_form = _(
+        'Please enter *either* a pdf file or a url link, but not both.')
     # Translators: When a user tries to make a duplicate account. %s is the email (i.e. joesmith@canada.ca)
     user_already_exists = _('Username %s already exists.')
     # Translators: When a user tries to sign on with something that isn't a government email. %s is the email domain (i.e. email.ca)
-    invalid_email_domain = _('Invalid e-mail address domain: %s. Canada.ca email required.')
+    invalid_email_domain = _(
+        'Invalid e-mail address domain: %s. Canada.ca email required.')
     # Translators: When a user tries to login with an unauthenticated account
     unconfirmed_email = _('Email address for user not confirmed.')
     # Translators: When a user submits an invalid username and/or password.
@@ -25,7 +28,7 @@ class ErrorMessages():
 
 class InterfaceText():
     # Translators: Sidebar
-    view_positions =_('View Positions')
+    view_positions = _('View Positions')
     # Translators: Sidebar
     new_position = _('New Position')
     # Translators: Sidebar
@@ -36,7 +39,8 @@ class InterfaceText():
 
 class PositionText():
     # Translators: Confirming Position Information
-    we_think_this_is_correct =_('We think this is the position. Can you take a look and make sure it is correct?')
+    we_think_this_is_correct = _(
+        'We think this is the position. Can you take a look and make sure it is correct?')
     # Translators: Confirming Position Information
     classification = _('Classification')
     # Translators: Confirming Position Information
@@ -61,7 +65,8 @@ class CreatePositionFormText():
     # Translators: CreatePositionForm
     upload_new_position = _("Upload New Position")
     # Translators: CreatePositionForm
-    please_select_either_filetype = _("Please select either PDF or link to the jobs.gc.ca posting")
+    please_select_either_filetype = _(
+        "Please select either PDF or link to the jobs.gc.ca posting")
     # Translators: CreatePositionForm
     pdf = _("PDF")
     # Translators: CreatePositionForm
@@ -91,7 +96,7 @@ class CreateAccountFormText():
     have_an_account_sign_in = _("Have an account? Sign in")
     # Translators: CreatePositionForm
     account_created = _(
-        "Account created. Please check your e-mail for an activation link")
+        "Account %s created. Please check your e-mail for an activation link.")
 
 
 class LoginFormText():
@@ -99,9 +104,10 @@ class LoginFormText():
     login = _("Login")
     # Translators: LoginForm
     password = _('Password')
+    # Translators: LoginForm
+    account_confirmed = _("Account %s confirmed. Please sign in below.")
 
 
-
-#translate command (in web sh): python manage.py makemessages -l pl
-#note: Translators: is specific syntax that makes the comment appear in the translation file
-#dont omit it
+# translate command (in web sh): python manage.py makemessages -l pl
+# note: Translators: is specific syntax that makes the comment appear in the translation file
+# dont omit it


### PR DESCRIPTION
When a user registers an account, they are given a confirmation
message on the create account page requesting they check their e-mail
for a link to confirm the account. The create account button is
disabled after the initial account creation is successful. The
confirmation URL will redirect the user to the login page, where
validation success or failure messages will be displayed, and the user
can then log in.