### PR TITLE
Implemented pop-ups to read applicant complementary responses

### DIFF
--- a/screendoor/templates/application.html
+++ b/screendoor/templates/application.html
@@ -248,7 +248,7 @@
               <tr class="question-full-header hide" id="previews-full{{ forloop.counter0 }}">
                 <td colspan="1"></td>
                 <td colspan="1">{% if answer.parent_question.parent_requirement is not None %}<span class="requirement-abbreviation-hidden"><span class="tooltiptext">{{ answer.parent_question.parent_requirement.abbreviation }}: {{ answer.parent_question.parent_requirement.description }}</span>{{ answer.parent_question.parent_requirement.abbreviation }}</span>
-                    {% endif %}</td>
+                  {% endif %}</td>
                 <td colspan="{% if answer.applicant_answer is True %}10
                              {% else %}23{% endif %}">
                   <span class="question-full">
@@ -329,34 +329,44 @@
             <tbody class="{% if answer.applicant_answer == True %}yes-answer-light{% else %}no-answer-light{% endif %} applicant-full-answer hide">
               <tr>
                 <td colspan="2"></td>
-                <td colspan="12" style="white-space: pre-line;" class="answer-complementary-response">{{ answer.applicant_complementary_response|bullet_points }}</td>
-                <data class="answer-id" value="{{ answer.id }}" />
-                <td colspan="1"></td>
-                <td colspan="10" class="blue-text text-darken-2 extract-full">
-                  {% for extract in answer.extract_set|dictsort:"extract_sentence_index" %}
-                  <data class="extract-string-index" value="{{ extract.extract_sentence_index }}"/>
-                  <data class="extract-ending-index" value="{{ extract.extract_ending_index }}"/>
-                  <data class="extract-next-index" value="{{ extract.next_extract_index }}"/>
-                  <data class="extract-string" value="{{ extract.extract_text }}"/>
-                  <data class="extract-id" value="{{ extract.id }}"/>
-                  <data class="extract-parent-answer-id" value="{{ extract.parent_answer.id }}"/>
-                  <data class="extract-parent-answer" value="{{ extract.parent_answer.applicant_complementary_response|bullet_points }}"/>
-                  {% if extract.extract_type == 'WHEN' %}
-                  <i class="material-icons extract-icon">date_range</i>
-                  {% elif extract.extract_type == 'HOW' %}
-                  <i class="material-icons extract-icon">work</i>
-                  {% endif %}
-                  <span class="extract-text">{{ extract.extract_text|capfirst|linebreaks }}</span>
-                  {% if extract.next_extract_index > extract.extract_sentence_index and not forloop.last %}
-                  <br>
-                  {% endif %}
-                  {% endfor %}
-                  {% if answer.extract_set is None %}
-                  <i class="material-icons extract-icon">clear</i>
-                  <span class="extract-preview">{{ applicantText.no_analysis }}</span>
-                  {% endif %}
-                </td>
-                <td colspan="1"></td>
+                <td colspan="12" style="white-space: pre-line;" class="answer-complementary-response"><a class="modal-trigger" href="#complementary-response-modal{{ forloop.counter0 }}">{{ answer.applicant_complementary_response|bullet_points }}</a></td>
+                <!-- Modal Structure -->
+                  <div id="complementary-response-modal{{ forloop.counter0 }}" class="modal response-modal">
+                    <div class="modal-content response-modal"><h5>Question {{ forloop.counter }}</h5>
+                      <h6 style="white-space: pre-line;">{{ answer.parent_question.question_text }}</h6>
+                      <h6 class="modal-complementary-question">{{ answer.parent_question.complementary_question_text }}:</h6>
+                      <p class="modal-complementary-response">{{ answer.applicant_complementary_response|bullet_points }}</p>
+                    </div>
+                    <a href="#!" class="modal-close btn-flat right response-modal-close">Close</a>
+                  </div>
+
+                  <data class="answer-id" value="{{ answer.id }}" />
+                  <td colspan="1"></td>
+                  <td colspan="10" class="blue-text text-darken-2 extract-full">
+                    {% for extract in answer.extract_set|dictsort:"extract_sentence_index" %}
+                    <data class="extract-string-index" value="{{ extract.extract_sentence_index }}"/>
+                    <data class="extract-ending-index" value="{{ extract.extract_ending_index }}"/>
+                    <data class="extract-next-index" value="{{ extract.next_extract_index }}"/>
+                    <data class="extract-string" value="{{ extract.extract_text }}"/>
+                    <data class="extract-id" value="{{ extract.id }}"/>
+                    <data class="extract-parent-answer-id" value="{{ extract.parent_answer.id }}"/>
+                    <data class="extract-parent-answer" value="{{ extract.parent_answer.applicant_complementary_response|bullet_points }}"/>
+                    {% if extract.extract_type == 'WHEN' %}
+                    <i class="material-icons extract-icon">date_range</i>
+                    {% elif extract.extract_type == 'HOW' %}
+                    <i class="material-icons extract-icon">work</i>
+                    {% endif %}
+                    <span class="extract-text">{{ extract.extract_text|capfirst|linebreaks }}</span>
+                    {% if extract.next_extract_index > extract.extract_sentence_index and not forloop.last %}
+                    <br>
+                    {% endif %}
+                    {% endfor %}
+                    {% if answer.extract_set is None %}
+                    <i class="material-icons extract-icon">clear</i>
+                    <span class="extract-preview">{{ applicantText.no_analysis }}</span>
+                    {% endif %}
+                  </td>
+                  <td colspan="1"></td>
               </tr>
             </tbody>
             {% endif %}
@@ -378,10 +388,12 @@
   <script src="{% static 'js/tables.js' %}"></script>
   <!-- Script for extract origin highlighting -->
   <script src="{% static 'js/sentence-highlighting.js' %}"></script>
+  <!-- Script for initializing modal pop-ups -->
+  <script src="{% static 'js/modal.js' %}"></script>
   <script>
    document.addEventListener('DOMContentLoaded', function() {
-     var elems = document.querySelectorAll('.tooltipped');
-     var instances = M.Tooltip.init(elems, {});
+     var tooltips = document.querySelectorAll('.tooltipped');
+     var tooltipInstances = M.Tooltip.init(tooltips, {});
    });
   </script>
   {% endblock %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6,6 +6,64 @@
   padding-left: 0px;
 }
 
+.modal-complementary-response {
+  white-space: pre-line;
+  font-size: 1.1rem;
+  margin-left: 15px;
+  padding-left: 15px;
+  margin-bottom: -25px;
+}
+
+.answer-complementary-response a {
+  color: #333333;
+}
+
+.modal-content.response-modal {
+  margin-top: -20px;
+}
+
+.modal-complementary-question {
+  padding-bottom: 15px;
+}
+
+.response-modal-close {
+  margin-bottom: 15px;
+}
+
+.modal.response-modal {
+  display: none;
+  position: fixed;
+  left: 0;
+  right: 0;
+  white-space: pre-line;
+  background-color: #fafafa;
+  padding: 0;
+  max-height: 70%;
+  width: 90%;
+  margin: auto;
+  overflow-y: auto;
+  border-radius: 2px;
+  will-change: top, opacity; }
+.modal:focus {
+  outline: none; }
+@media only screen and (max-width: 992px) {
+  .modal {
+    width: 80%; } }
+.modal h1, .modal h2, .modal h3, .modal h4 {
+  margin-top: 0; }
+.modal .modal-content {
+  padding: 24px; }
+.modal .modal-close {
+  cursor: pointer; }
+.modal .modal-footer {
+  border-radius: 0 0 2px 2px;
+  background-color: #fafafa;
+  padding: 4px 6px;
+  height: 56px;
+  width: 100%;
+  text-align: right; }
+.modal .modal-footer .btn, .modal .modal-footer .btn-large, .modal .modal-footer .btn-small, .modal .modal-footer .btn-flat {
+  margin: 6px 0; }
 .logged-out-logo {
   margin-left: 25px;
 }

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -2,3 +2,6 @@
 const modalElements = document.querySelectorAll('.modal');
 const modalInstances = M.Modal.init(modalElements, {} /* options */ );
 const uploadModal = modalInstances[2];
+
+const responseModals = document.querySelectorAll('.modal.response-modal') ?  document.querySelectorAll('.modal.response-modal') : null;
+const responseModalInstances = document.querySelectorAll('.modal.response-modal') ? M.Modal.init(responseModals, {} /* options */ ) : null;

--- a/static/js/sentence-highlighting.js
+++ b/static/js/sentence-highlighting.js
@@ -46,7 +46,7 @@ const highlightSentence = function(extractIndex, answerId) {
       const answerHighlight = "<span id='answer-highlight' class='answer-highlight'>" + answerText.slice(startIndex, endIndex) + "</span>";
       const answerAfter = answerText.slice(endIndex);
 
-      answerComplementaryResponse[i].innerHTML = answerBefore + answerHighlight + answerAfter;
+      answerComplementaryResponse[i].innerHTML = "<a class='modal-trigger' href='#complementary-response-modal" + i + "' >" + answerBefore + answerHighlight + answerAfter + "</a>";
       document.getElementById('answer-highlight').classList.add("answer-highlighted");
     }
   }
@@ -58,7 +58,7 @@ const unHighlightSentence = function(extractIndex, answerId) {
 
   for (let i = 0; i < answerComplementaryResponse.length; i++) {
     if (answerComplementaryResponse[i].answerId.value == answerId) {
-      answerComplementaryResponse[i].innerHTML = extractParentAnswerTexts[extractIndex].value;
+      answerComplementaryResponse[i].innerHTML = "<a class='modal-trigger' href='#complementary-response-modal" + i + "' >" + extractParentAnswerTexts[extractIndex].value + "</a>";
     }
   }
 };


### PR DESCRIPTION
In the applicant view, clicking on an applicant's complementary
response will cause a box to pop up inside the browser window
containing the question details, and the applicant's response. The
purpose of this is to facilitate easier reading of the applicant's
full response.