### PR TITLE
Fixed upload directory name; task deletes temp files

### DIFF
--- a/screendoor/parseposter.py
+++ b/screendoor/parseposter.py
@@ -644,7 +644,6 @@ def parse_poster_text_from_file(pdf_file):
     job_poster_text = file_data['content']
     job_poster_text = correct_poster_for_external_access(job_poster_text)
     job_poster_text = scrub_raw_text(job_poster_text)
-
     return job_poster_text
 
 

--- a/screendoor/tasks.py
+++ b/screendoor/tasks.py
@@ -1,6 +1,8 @@
 import string
 import time
 import os
+import re
+import os.path
 from celery import shared_task, current_task
 from celery.contrib import rdb
 from celery.result import AsyncResult
@@ -46,15 +48,19 @@ def process_applications(self, file_paths, position_id):
 
 # Scheduled tasks
 
-
-# Once per day
 @shared_task
 def delete_authorization_tokens():
     EmailAuthenticateToken.objects.filter(created=datetime.now() -
                                           timedelta(days=2)).delete()
 
 
-# Once per day
 @shared_task
 def delete_orphaned_positions():
     Position.objects.filter(position_users=None).delete()
+
+
+@shared_task
+def delete_temp_files():
+    for root, dirs, files, in os.walk("temp"):
+        for file in files:
+            os.remove(os.path.join(root, file))

--- a/screendoor_app/settings.py
+++ b/screendoor_app/settings.py
@@ -168,12 +168,11 @@ PASSWORD_RESET_TIMEOUT_DAYS = 1
 #     "django.core.files.uploadhandler.TemporaryFileUploadHandler",)
 
 # FILE_UPLOAD_TEMP_DIR = ("/code/screendoor/temp")
-MEDIA_URL = 'code/screendoor/temp/'
-MEDIA_ROOT = os.path.join(BASE_DIR, 'code/screendoor/temp')
-FILE_UPLOAD_PERMISSIONS = 0o644
-FILE_UPLOAD_DIRECTORY_PERMISSIONS = 0o644
+MEDIA_URL = 'temp/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'temp')
+FILE_UPLOAD_PERMISSIONS = 0o666
+FILE_UPLOAD_DIRECTORY_PERMISSIONS = 0o666
 # FILE_UPLOAD_MAX_MEMORY_SIZE = 0
-# MEDIA_ROOT = ("/code/screendoor/temp")
 
 # Celery Settings
 
@@ -184,10 +183,14 @@ CELERYD_STATE_DB = '/tmp/celery_state'
 CELERY_BEAT_SCHEDULE = {
     'delete_authorization_tokens': {
         'task': 'screendoor.tasks.delete_authorization_tokens',
-        'schedule': crontab(hour='*/2')
+        'schedule': crontab(minute=0, hour='*/3')
     },
     'delete_orphaned_positions': {
         'task': 'screendoor.tasks.delete_orphaned_positions',
-        'schedule': crontab(hour='*/2')
+        'schedule': crontab(minute=0, hour='*/3')
+    },
+    'delete_temp_files': {
+        'task': 'screendoor.tasks.delete_temp_files',
+        'schedule': crontab(minute=0, hour='*/3')
     }
 }


### PR DESCRIPTION
Temporary files are no longer uploaded to a "code" directory but a "temp" directory in the project root.

A scheduled task now deletes temporary files (position PDFs or applicant PDFs from failed processing)